### PR TITLE
Fixing getTemplatesPath() / setTemplatesPath() deprecation errors.

### DIFF
--- a/lj_dynamicfields/Lj_DynamicFieldsPlugin.php
+++ b/lj_dynamicfields/Lj_DynamicFieldsPlugin.php
@@ -10,7 +10,7 @@ class Lj_DynamicFieldsPlugin extends BasePlugin
 
     function getVersion()
     {
-        return '0.5';
+        return '0.6';
     }
 
     function getDeveloper()
@@ -21,5 +21,18 @@ class Lj_DynamicFieldsPlugin extends BasePlugin
     function getDeveloperUrl()
     {
         return 'http://lewisjenkins.co.uk';
+    }
+
+    /**
+     * Require Craft 2.6.2778
+     *
+     * @throws Exception
+     */
+    public function onBeforeInstall()
+    {
+      if (version_compare(craft()->getVersion().'.'.craft()->getBuild(), '2.6.2778', '<'))
+      {
+        throw new Exception('LJ Dynamic Fields 0.6+ requires Craft CMS 2.6.2778+ in order to run.');
+      }
     }
 }

--- a/lj_dynamicfields/fieldtypes/Lj_DynamicFields_CheckboxesFieldType.php
+++ b/lj_dynamicfields/fieldtypes/Lj_DynamicFields_CheckboxesFieldType.php
@@ -11,50 +11,50 @@ class Lj_DynamicFields_CheckboxesFieldType extends BaseFieldType
 
 	public function getInputHtml($name, $values)
 	{
-		$oldTemplatesPath = craft()->path->getTemplatesPath();
-		craft()->path->setTemplatesPath(craft()->path->getSiteTemplatesPath());
-		
+		$oldMode = craft()->templates->getTemplateMode();
+		craft()->templates->setTemplateMode(TemplateMode::Site);
+
 		$variables = array();
 		foreach (craft() -> globals -> getAllSets() as $globalSet) :
 			$variables[$globalSet->handle] = $globalSet;
 		endforeach;
-		
+
 		$variables['element'] = $this->element;
 		$variables['model'] = $this->model;
-		
+
 		$options = json_decode('[' . craft()->templates->renderString($this->getSettings()->json, $variables) . ']', true);
-		craft()->path->setTemplatesPath($oldTemplatesPath);
-		
+		craft()->templates->setTemplateMode($oldMode);
+
 		if ($this->isFresh()) :
-		
+
 		$values = array();
-		
+
 			foreach ($options as $option) :
 				if (!empty($option['default'])) :
 					$values[] = $option['value'];
 				endif;
 			endforeach;
 		endif;
-		
+
 		return craft()->templates->render('_includes/forms/checkboxGroup', array(
 			'name' => $name,
 			'values' => $values,
 			'options' => $options
 		));
 	}
-	
+
 	protected function defineSettings()
     {
         return array(
             'json' => array(AttributeType::String)
         );
     }
-	
+
 	public function defineContentAttribute()
     {
         return AttributeType::Mixed;
     }
-	
+
 	public function getSettingsHtml()
     {
         return craft()->templates->render('lj_dynamicfields/settings/checkboxes', array(

--- a/lj_dynamicfields/fieldtypes/Lj_DynamicFields_DropdownFieldType.php
+++ b/lj_dynamicfields/fieldtypes/Lj_DynamicFields_DropdownFieldType.php
@@ -11,20 +11,20 @@ class Lj_DynamicFields_DropdownFieldType extends BaseFieldType
 
 	public function getInputHtml($name, $value)
 	{
-		$oldTemplatesPath = craft()->path->getTemplatesPath();
-		craft()->path->setTemplatesPath(craft()->path->getSiteTemplatesPath());
-		
+		$oldMode = craft()->templates->getTemplateMode();
+		craft()->templates->setTemplateMode(TemplateMode::Site);
+
 		$variables = array();
 		foreach (craft() -> globals -> getAllSets() as $globalSet) :
 			$variables[$globalSet->handle] = $globalSet;
 		endforeach;
-		
+
 		$variables['element'] = $this->element;
 		$variables['model'] = $this->model;
-		
+
 		$options = json_decode('[' . craft()->templates->renderString($this->getSettings()->json, $variables) . ']', true);
-		craft()->path->setTemplatesPath($oldTemplatesPath);
-		
+		craft()->templates->setTemplateMode($oldMode);
+
 		if ($this->isFresh()) :
 			foreach ($options as $option) :
 				if (!empty($option['default'])) :
@@ -33,26 +33,26 @@ class Lj_DynamicFields_DropdownFieldType extends BaseFieldType
 				endif;
 			endforeach;
 		endif;
-		
+
 		return craft()->templates->render('_includes/forms/select', array(
 			'name' => $name,
 			'value' => $value,
 			'options' => $options
 		));
 	}
-	
+
 	protected function defineSettings()
     {
         return array(
             'json' => array(AttributeType::String)
         );
     }
-	
+
 	public function defineContentAttribute()
     {
         return AttributeType::String;
     }
-	
+
 	public function getSettingsHtml()
     {
         return craft()->templates->render('lj_dynamicfields/settings/dropdown', array(

--- a/lj_dynamicfields/fieldtypes/Lj_DynamicFields_MultiSelectFieldType.php
+++ b/lj_dynamicfields/fieldtypes/Lj_DynamicFields_MultiSelectFieldType.php
@@ -11,50 +11,50 @@ class Lj_DynamicFields_MultiSelectFieldType extends BaseFieldType
 
 	public function getInputHtml($name, $values)
 	{
-		$oldTemplatesPath = craft()->path->getTemplatesPath();
-		craft()->path->setTemplatesPath(craft()->path->getSiteTemplatesPath());
-		
+		$oldMode = craft()->templates->getTemplateMode();
+		craft()->templates->setTemplateMode(TemplateMode::Site);
+
 		$variables = array();
 		foreach (craft() -> globals -> getAllSets() as $globalSet) :
 			$variables[$globalSet->handle] = $globalSet;
 		endforeach;
-		
+
 		$variables['element'] = $this->element;
 		$variables['model'] = $this->model;
-		
+
 		$options = json_decode('[' . craft()->templates->renderString($this->getSettings()->json, $variables) . ']', true);
-		craft()->path->setTemplatesPath($oldTemplatesPath);
-		
+		craft()->templates->setTemplateMode($oldMode);
+
 		if ($this->isFresh()) :
-		
+
 		$values = array();
-		
+
 			foreach ($options as $option) :
 				if (!empty($option['default'])) :
 					$values[] = $option['value'];
 				endif;
 			endforeach;
 		endif;
-		
+
 		return craft()->templates->render('_includes/forms/multiselect', array(
 			'name' => $name,
 			'values' => $values,
 			'options' => $options
 		));
 	}
-	
+
 	protected function defineSettings()
     {
         return array(
             'json' => array(AttributeType::String)
         );
     }
-	
+
 	public function defineContentAttribute()
     {
         return AttributeType::Mixed;
     }
-	
+
 	public function getSettingsHtml()
     {
         return craft()->templates->render('lj_dynamicfields/settings/multiselect', array(

--- a/lj_dynamicfields/fieldtypes/Lj_DynamicFields_RadioButtonsFieldType.php
+++ b/lj_dynamicfields/fieldtypes/Lj_DynamicFields_RadioButtonsFieldType.php
@@ -11,20 +11,20 @@ class Lj_DynamicFields_RadioButtonsFieldType extends BaseFieldType
 
 	public function getInputHtml($name, $value)
 	{
-		$oldTemplatesPath = craft()->path->getTemplatesPath();
-		craft()->path->setTemplatesPath(craft()->path->getSiteTemplatesPath());
-		
+		$oldMode = craft()->templates->getTemplateMode();
+		craft()->templates->setTemplateMode(TemplateMode::Site);
+
 		$variables = array();
 		foreach (craft() -> globals -> getAllSets() as $globalSet) :
 			$variables[$globalSet->handle] = $globalSet;
 		endforeach;
-		
+
 		$variables['element'] = $this->element;
 		$variables['model'] = $this->model;
-		
+
 		$options = json_decode('[' . craft()->templates->renderString($this->getSettings()->json, $variables) . ']', true);
-		craft()->path->setTemplatesPath($oldTemplatesPath);
-		
+		craft()->templates->setTemplateMode($oldMode);
+
 		if ($this->isFresh()) :
 			foreach ($options as $option) :
 				if (!empty($option['default'])) :
@@ -33,26 +33,26 @@ class Lj_DynamicFields_RadioButtonsFieldType extends BaseFieldType
 				endif;
 			endforeach;
 		endif;
-		
+
 		return craft()->templates->render('_includes/forms/radioGroup', array(
 			'name' => $name,
 			'value' => $value,
 			'options' => $options
 		));
 	}
-	
+
 	protected function defineSettings()
     {
         return array(
             'json' => array(AttributeType::String)
         );
     }
-	
+
 	public function defineContentAttribute()
     {
         return AttributeType::String;
     }
-	
+
 	public function getSettingsHtml()
     {
         return craft()->templates->render('lj_dynamicfields/settings/radiobuttons', array(


### PR DESCRIPTION
This ends up requiring Craft 2.6.2778+ as a result. See detailed discussion on StackExchange [here](http://craftcms.stackexchange.com/questions/14375/how-do-i-fix-gettemplatespath-settemplatespath-deprecation-errors).