### PR TITLE
fixes deprecation error

### DIFF
--- a/lj_dynamicfields/Lj_DynamicFieldsPlugin.php
+++ b/lj_dynamicfields/Lj_DynamicFieldsPlugin.php
@@ -30,7 +30,7 @@ class Lj_DynamicFieldsPlugin extends BasePlugin
      */
     public function onBeforeInstall()
     {
-      if (version_compare(craft()->getVersion().'.'.craft()->getBuild(), '2.6.2778', '<'))
+      if (version_compare(craft()->getVersion(), '2.6.2778', '<'))
       {
         throw new Exception('LJ Dynamic Fields 0.6+ requires Craft CMS 2.6.2778+ in order to run.');
       }


### PR DESCRIPTION
Updates version comparison to use `craft->getVersion()` only since it now returns the full version.